### PR TITLE
Various fixes and improvements

### DIFF
--- a/Application/interface/CMSApplication.h
+++ b/Application/interface/CMSApplication.h
@@ -26,16 +26,12 @@ class CMSApplication : public geant::UserApplication {
 		void FinishEvent(geant::Event *event) override;
 		void FinishRun() override;
 
-		//methods for CMSSW data access
-		CMSDataPerEvent& GetEventData(int slot);
-
 	private:
 		//member variables
 		edm::ParameterSet fParams;
 		bool fInitialized;
 		int fNumBufferedEvents;
 		geant::TaskDataHandle<CMSDataPerThread> *fDataHandler;
-		std::vector<CMSDataPerEvent> fEventData;
 };
 
 #endif

--- a/Application/interface/CMSApplication.h
+++ b/Application/interface/CMSApplication.h
@@ -35,7 +35,7 @@ class CMSApplication : public geant::UserApplication {
 		bool fInitialized;
 		int fNumBufferedEvents;
 		geant::TaskDataHandle<CMSDataPerThread> *fDataHandler;
-		std::vector<CMSDataPerEvent*> fEventData;
+		std::vector<CMSDataPerEvent> fEventData;
 };
 
 #endif

--- a/Application/interface/CMSData.h
+++ b/Application/interface/CMSData.h
@@ -28,6 +28,7 @@ class CMSDataPerEvent : public GVScoring {
 		//specialized copy constructor
 		CMSDataPerEvent(const CMSDataPerEvent& orig);
 		~CMSDataPerEvent() {}
+		CMSDataPerEvent& operator=(const CMSDataPerEvent& other);
 
 		//common scoring interface
 		void BeginRun() override;
@@ -39,6 +40,7 @@ class CMSDataPerEvent : public GVScoring {
 		//for final output
 		bool Merge(const CMSDataPerEvent& other);
 		void produce(edm::Event&, const edm::EventSetup&);
+		void clear() { fSD->clear(); }
 
 	private:
 		//member variables
@@ -52,7 +54,10 @@ class CMSDataPerThread : public GVScoring {
 		~CMSDataPerThread() {}
 
 		//required interface
-		void Clear(int index) {} //DataPerEvent clears itself when BeginEvent() is called
+		void Clear(int index) {
+			//avoid holding on to memory after merging
+			fDataPerEvent[index].clear();
+		}
 		bool Merge(int index, const CMSDataPerThread& other);
 
 		//common scoring interface
@@ -63,7 +68,7 @@ class CMSDataPerThread : public GVScoring {
 		void FinishRun() override;
 
 		//for final output
-		CMSDataPerEvent* GetEventData(int slot);
+		const CMSDataPerEvent& GetEventData(int slot);
 
 	private:
 		//member variables

--- a/Application/interface/CMSData.h
+++ b/Application/interface/CMSData.h
@@ -39,8 +39,7 @@ class CMSDataPerEvent : public GVScoring {
 
 		//for final output
 		bool Merge(const CMSDataPerEvent& other);
-		void produce(edm::Event&, const edm::EventSetup&);
-		void clear() { fSD->clear(); }
+		CaloSteppingAction* GetData() { return fSD.get(); }
 
 	private:
 		//member variables
@@ -54,10 +53,7 @@ class CMSDataPerThread : public GVScoring {
 		~CMSDataPerThread() {}
 
 		//required interface
-		void Clear(int index) {
-			//avoid holding on to memory after merging
-			fDataPerEvent[index].clear();
-		}
+		void Clear(int index) {}
 		bool Merge(int index, const CMSDataPerThread& other);
 
 		//common scoring interface
@@ -68,7 +64,7 @@ class CMSDataPerThread : public GVScoring {
 		void FinishRun() override;
 
 		//for final output
-		const CMSDataPerEvent& GetEventData(int slot);
+		CaloSteppingAction* GetEventData(int slot) { return fDataPerEvent[slot].GetData(); }
 
 	private:
 		//member variables

--- a/Application/interface/CMSData.h
+++ b/Application/interface/CMSData.h
@@ -40,6 +40,7 @@ class CMSDataPerEvent : public GVScoring {
 		//for final output
 		bool Merge(const CMSDataPerEvent& other);
 		CaloSteppingAction* GetData() { return fSD.get(); }
+		void clear() { fSD->clear(); }
 
 	private:
 		//member variables
@@ -53,7 +54,7 @@ class CMSDataPerThread : public GVScoring {
 		~CMSDataPerThread() {}
 
 		//required interface
-		void Clear(int index) {}
+		void Clear(int index) { fDataPerEvent[index].clear(); }
 		bool Merge(int index, const CMSDataPerThread& other);
 
 		//common scoring interface

--- a/Application/interface/CMSEvent.h
+++ b/Application/interface/CMSEvent.h
@@ -1,0 +1,41 @@
+#ifndef SimGVCore_Application_CMSEvent_h
+#define SimGVCore_Application_CMSEvent_h
+
+#include "FWCore/Concurrency/interface/WaitingTaskWithArenaHolder.h"
+
+#include "Geant/Event.h"
+
+//stream cache to keep track of GeantV event scoring output
+struct EventCache {
+	void clear() {
+		sd_ = nullptr;
+	}
+
+	std::unique_ptr<CaloSteppingAction> sd_ = nullptr;
+};
+
+// an event with a callback
+class CMSEvent : public geant::Event {
+	public:
+		CMSEvent(edm::WaitingTaskWithArenaHolder holder, EventCache* cache) : holder_(std::move(holder)), cache_(cache) {
+			//clear cache values
+			cache_->clear();
+		}
+
+		//set cache values
+		void Store(const CaloSteppingAction& sd){
+			cache_->sd_ = std::make_unique<CaloSteppingAction>(sd);
+		}
+
+		void FinalActions() override {
+			edm::LogInfo("GeantVProducer") << "Callback for event " << this;
+			std::exception_ptr exceptionPtr;
+			holder_.doneWaiting(exceptionPtr);
+		}
+
+	private:
+		edm::WaitingTaskWithArenaHolder holder_;
+		EventCache* cache_;
+};
+
+#endif

--- a/Application/plugins/GeantVProducer.cc
+++ b/Application/plugins/GeantVProducer.cc
@@ -43,6 +43,7 @@
 #include "Geant/PhysicsListManager.h"
 
 #include "SimGVCore/CaloGV/interface/CaloSteppingAction.h"
+#include "SimGVCore/Application/interface/CMSEvent.h"
 #include "SimGVCore/Application/interface/CMSData.h"
 #include "SimGVCore/Application/interface/CMSApplication.h"
 #include "SimGVCore/Application/interface/CMSPhysicsListX.h"
@@ -77,35 +78,12 @@ namespace {
 }
 
 //dummy run cache to get access to global begin run
-//stream cache to keep track of GeantV event slot number
-typedef int SlotCache;
-class GeantVProducer : public edm::global::EDProducer<edm::ExternalWork,edm::RunCache<int>,edm::StreamCache<SlotCache>> {
+class GeantVProducer : public edm::global::EDProducer<edm::ExternalWork,edm::RunCache<int>,edm::StreamCache<EventCache>> {
   public:
-    // an event with a callback
-    class EventCB : public geant::Event {
-        public:
-            EventCB(edm::WaitingTaskWithArenaHolder holder, SlotCache* slot) : holder_(std::move(holder)), slot_(slot) {
-				//clear slot value
-				*slot_ = -1;
-			}
-
-            void FinalActions() override {
-				//set slot value
-				*slot_ = this->GetSlot();
-				edm::LogInfo("GeantVProducer") << "Callback for event " << this;
-                std::exception_ptr exceptionPtr;
-                holder_.doneWaiting(exceptionPtr);
-            }
-
-        private:
-            edm::WaitingTaskWithArenaHolder holder_;
-			SlotCache* slot_;
-    };
-
     GeantVProducer(edm::ParameterSet const&);
     ~GeantVProducer() override;
 
-	std::unique_ptr<SlotCache> beginStream(edm::StreamID) const override;
+	std::unique_ptr<EventCache> beginStream(edm::StreamID) const override;
 
     void acquire(edm::StreamID, edm::Event const&, edm::EventSetup const&, edm::WaitingTaskWithArenaHolder) const override;
 
@@ -123,7 +101,7 @@ class GeantVProducer : public edm::global::EDProducer<edm::ExternalWork,edm::Run
     Not required as application functionality, the event reading or generation
     can in the external event loop.
     */
-    std::unique_ptr<geant::EventSet> GenerateEventSet(const HepMC::GenEvent * evt, long long event_index, edm::WaitingTaskWithArenaHolder iHolder, SlotCache* slot, TaskData *td) const;
+    std::unique_ptr<geant::EventSet> GenerateEventSet(const HepMC::GenEvent * evt, long long event_index, edm::WaitingTaskWithArenaHolder iHolder, EventCache* cache, TaskData *td) const;
 
 	edm::ParameterSet scoringParams;
     // e.g. cms2015.root, cms2018.gdml, ExN03.root
@@ -157,8 +135,8 @@ GeantVProducer::~GeantVProducer() {
     delete fRunMgr;
 }
 
-std::unique_ptr<SlotCache> GeantVProducer::beginStream(edm::StreamID) const {
-	return std::make_unique<SlotCache>(-1);
+std::unique_ptr<EventCache> GeantVProducer::beginStream(edm::StreamID) const {
+	return std::make_unique<EventCache>();
 }
 
 void GeantVProducer::preallocate(edm::PreallocationConfiguration const& iPrealloc) {
@@ -299,8 +277,8 @@ void GeantVProducer::acquire(edm::StreamID iStream, edm::Event const& iEvent, ed
     }
 
     // ... then create the event set
-	auto slot = streamCache(iStream);
-    auto evset = GenerateEventSet(evt, event_index, iHolder, slot, td);
+	auto cache = streamCache(iStream);
+    auto evset = GenerateEventSet(evt, event_index, iHolder, cache, td);
 
     edm::Service<edm::RootHandlers> rootHandler;
     auto rootHandlerPtr = &(*rootHandler);
@@ -327,17 +305,16 @@ void GeantVProducer::produce(edm::StreamID iStream, edm::Event& iEvent, edm::Eve
 
 	//get the event data back from GeantV
 	//the "final" DataPerEvent object after merging puts the products into the event
-	auto slot = streamCache(iStream);
-	auto cmsApp = static_cast<CMSApplication*>(fRunMgr->GetUserApplication());
-	cmsApp->GetEventData(*slot).produce(iEvent,iSetup);
+	auto cache = streamCache(iStream);
+	cache->sd_->produce(iEvent,iSetup);
     //don't hang on to memory
-    cmsApp->GetEventData(*slot).clear();
+	cache->clear();
 
     edm::LogInfo("GeantVProducer") <<" at "<< this <<": done!";
 }
 
 // eventually this can become more like SimG4Core/Generators/interface/Generator.h
-std::unique_ptr<geant::EventSet> GeantVProducer::GenerateEventSet(const HepMC::GenEvent * evt, long long event_index, edm::WaitingTaskWithArenaHolder iHolder, SlotCache* slot, geant::TaskData *td) const
+std::unique_ptr<geant::EventSet> GeantVProducer::GenerateEventSet(const HepMC::GenEvent * evt, long long event_index, edm::WaitingTaskWithArenaHolder iHolder, EventCache* cache, geant::TaskData *td) const
 {
     using EventSet = geant::EventSet;
     using Event = geant::Event;
@@ -345,7 +322,7 @@ std::unique_ptr<geant::EventSet> GeantVProducer::GenerateEventSet(const HepMC::G
 
     auto evset = std::make_unique<EventSet>(1);
     // keep track of the callback
-    auto event = std::make_unique<EventCB>(iHolder,slot);
+    auto event = std::make_unique<CMSEvent>(iHolder,cache);
 
     // convert from HepMC to GeantV format
     //event->SetEvent(evt->event_number());

--- a/Application/plugins/GeantVProducer.cc
+++ b/Application/plugins/GeantVProducer.cc
@@ -129,6 +129,7 @@ class GeantVProducer : public edm::global::EDProducer<edm::ExternalWork,edm::Run
     // e.g. cms2015.root, cms2018.gdml, ExN03.root
     std::string cms_geometry_filename;
     double zFieldInTesla;
+    bool singleTrackMode;
     edm::EDGetTokenT<edm::HepMCProduct> m_InToken;
     int n_threads;
     // cheating because run manager's functions modify its internal state
@@ -140,6 +141,7 @@ GeantVProducer::GeantVProducer(edm::ParameterSet const& iConfig) :
 	scoringParams(iConfig.getParameter<edm::ParameterSet>("Scoring")),
     cms_geometry_filename(iConfig.getParameter<std::string>("geometry")),
     zFieldInTesla(iConfig.getParameter<double>("ZFieldInTesla")),
+    singleTrackMode(iConfig.getParameter<bool>("singleTrackMode")),
     m_InToken(consumes<edm::HepMCProduct>(iConfig.getParameter<edm::InputTag>("HepMCProductLabel"))),
     n_threads(0),
 	fRunMgr(nullptr)
@@ -204,6 +206,7 @@ void GeantVProducer::initialize() const {
     GeantConfig* fConfig = new GeantConfig();
 
     fConfig->fRunMode = GeantConfig::kExternalLoop;
+    if(singleTrackMode) fConfig->fSingleTrackMode = true;
 
     fConfig->fGeomFileName = cms_geometry_filename;
     fConfig->fNtotal = 9999; //need to get nevents from somewhere

--- a/Application/plugins/GeantVProducer.cc
+++ b/Application/plugins/GeantVProducer.cc
@@ -330,6 +330,8 @@ void GeantVProducer::produce(edm::StreamID iStream, edm::Event& iEvent, edm::Eve
 	auto slot = streamCache(iStream);
 	auto cmsApp = static_cast<CMSApplication*>(fRunMgr->GetUserApplication());
 	cmsApp->GetEventData(*slot).produce(iEvent,iSetup);
+    //don't hang on to memory
+    cmsApp->GetEventData(*slot).clear();
 
     edm::LogInfo("GeantVProducer") <<" at "<< this <<": done!";
 }

--- a/Application/src/CMSApplication.cc
+++ b/Application/src/CMSApplication.cc
@@ -67,7 +67,10 @@ void CMSApplication::FinishEvent(geant::Event* event) {
 		data->FinishEvent(event);
 	}
 	//merge and store thread-local data for this event
-	static_cast<CMSEvent*>(event)->Store(*(fRunMgr->GetTDManager()->MergeUserData(event->GetSlot(), *fDataHandler)->GetEventData(event->GetSlot())));
+	auto base_data = fRunMgr->GetTDManager()->MergeUserData(event->GetSlot(), *fDataHandler);
+	static_cast<CMSEvent*>(event)->Store(*(base_data->GetEventData(event->GetSlot())));
+	//now clear out unneeded data
+	base_data->Clear(event->GetSlot());
 }
 
 void CMSApplication::SteppingActions(geant::Track &track, geant::TaskData *td) {

--- a/Application/src/CMSApplication.cc
+++ b/Application/src/CMSApplication.cc
@@ -19,7 +19,7 @@ bool CMSApplication::Initialize() {
 	fDataHandler = fRunMgr->GetTDManager()->RegisterUserData<CMSDataPerThread>("CMSDataPerThread");
 
 	//slots for output data
-	fEventData.resize(fNumBufferedEvents);
+	fEventData.resize(fNumBufferedEvents, fParams);
 
 	fInitialized = true;
 	return true;
@@ -78,5 +78,5 @@ void CMSApplication::SteppingActions(geant::Track &track, geant::TaskData *td) {
 }
 
 CMSDataPerEvent& CMSApplication::GetEventData(int slot) {
-	return *fEventData[slot];
+	return fEventData[slot];
 }

--- a/Application/src/CMSData.cc
+++ b/Application/src/CMSData.cc
@@ -11,8 +11,15 @@ CMSDataPerEvent::CMSDataPerEvent() : fSD(nullptr), fInitialized(false) { }
 
 CMSDataPerEvent::CMSDataPerEvent(const edm::ParameterSet& p) : fSD(std::make_unique<CaloSteppingAction>(p)), fInitialized(false) { }
 
-//SD class needs custom copy via Clone() function (contains unique_ptrs)
-CMSDataPerEvent::CMSDataPerEvent(const CMSDataPerEvent& orig) : fSD(orig.fSD ? std::make_unique<CaloSteppingAction>(orig.fSD->GetParams()) : nullptr), fInitialized(false) { }
+CMSDataPerEvent::CMSDataPerEvent(const CMSDataPerEvent& orig) : fSD(std::make_unique<CaloSteppingAction>(*orig.fSD)), fInitialized(orig.fInitialized) { }
+
+CMSDataPerEvent& CMSDataPerEvent::operator=(const CMSDataPerEvent& other) {
+	if(this != &other){
+		fSD = std::make_unique<CaloSteppingAction>(*other.fSD);
+		fInitialized = other.fInitialized;
+	}
+	return *this;
+}
 
 //pass calls through to SD class
 
@@ -81,7 +88,7 @@ bool CMSDataPerThread::Merge(int index, const CMSDataPerThread& other){
 	return fDataPerEvent[index].Merge(other.fDataPerEvent[index]);
 }
 
-CMSDataPerEvent* CMSDataPerThread::GetEventData(int slot) {
-	return &fDataPerEvent[slot];
+const CMSDataPerEvent& CMSDataPerThread::GetEventData(int slot) {
+	return fDataPerEvent[slot];
 }
 

--- a/Application/src/CMSData.cc
+++ b/Application/src/CMSData.cc
@@ -48,10 +48,6 @@ bool CMSDataPerEvent::Merge(const CMSDataPerEvent& other) {
 	return fSD->Merge(*other.fSD);
 }
 
-void CMSDataPerEvent::produce(edm::Event& e, const edm::EventSetup& s) {
-	fSD->produce(e, s);
-}
-
 //------------------------------------------------------------------------------------------
 //implementation of per-thread data
 
@@ -87,8 +83,3 @@ void CMSDataPerThread::FinishRun() {
 bool CMSDataPerThread::Merge(int index, const CMSDataPerThread& other){
 	return fDataPerEvent[index].Merge(other.fDataPerEvent[index]);
 }
-
-const CMSDataPerEvent& CMSDataPerThread::GetEventData(int slot) {
-	return fDataPerEvent[slot];
-}
-

--- a/Application/test/runCopy.py
+++ b/Application/test/runCopy.py
@@ -7,6 +7,7 @@ process = cms.Process('COPY')
 
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(['file:'+options._genname+'.root']*options.ncopy),
+    duplicateCheckMode = cms.untracked.string("noDuplicateCheck"),
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/Application/test/runSim.py
+++ b/Application/test/runSim.py
@@ -178,7 +178,7 @@ elif options.sim=="GV":
         HepMCProductLabel = cms.InputTag("generatorSmeared"),
         geometry = cms.string(""),
         ZFieldInTesla = cms.double(options.bfield),
-        singleTrackMode = cms.bool(True),
+        singleTrackMode = cms.bool(False),
         Scoring = scoring_,
     )
 

--- a/Application/test/runSim.py
+++ b/Application/test/runSim.py
@@ -178,6 +178,7 @@ elif options.sim=="GV":
         HepMCProductLabel = cms.InputTag("generatorSmeared"),
         geometry = cms.string(""),
         ZFieldInTesla = cms.double(options.bfield),
+        singleTrackMode = cms.bool(True),
         Scoring = scoring_,
     )
 

--- a/Application/test/testMT.sh
+++ b/Application/test/testMT.sh
@@ -4,7 +4,7 @@ TESTNAME=""
 SIM=""
 NEVENTS=0
 NCPU=$(cat /proc/cpuinfo | grep processor | wc -l)
-ARGS="particle=electron mult=2 energy=50 year=2018"
+ARGS="particle=electron mult=2 energy=50 year=2018 output=0"
 
 while getopts "t:a:s:n:" opt; do
 	case "$opt" in

--- a/Calo/interface/CaloMapT.h
+++ b/Calo/interface/CaloMapT.h
@@ -1,0 +1,60 @@
+#ifndef SimGVCore_Calo_CaloMapT_H
+#define SimGVCore_Calo_CaloMapT_H
+
+#include <vector>
+#include <map>
+#include <string>
+
+template <class Traits>
+class CaloMapT {
+	public:
+		typedef typename Traits::Volume Volume;
+		typedef typename Traits::VolumeWrapper VolumeWrapper;
+
+		//constructor
+		CaloMapT(const std::vector<std::string>& nameEBSD, const std::vector<std::string>& nameEESD, const std::vector<std::string>& nameHCSD) {
+			const auto& nameMap = VolumeWrapper::getVolumes();
+			for (auto const& name : nameEBSD) {
+				for (const auto& itr : nameMap) {
+					const std::string &lvname = itr.first;
+					if (lvname.find(name) != std::string::npos) {
+						volEBSD_.emplace_back(itr.second);
+						int type =	(lvname.find("refl") == std::string::npos) ? -1 : 1;
+						double dz = VolumeWrapper(itr.second).dz();
+						xtalMap_.emplace(itr.second,dz*type);
+					}
+				}
+			}
+			for (auto const& name : nameEESD) {
+				for (const auto& itr : nameMap) {
+					const std::string &lvname = itr.first;
+					if (lvname.find(name) != std::string::npos)	{
+						volEESD_.emplace_back(itr.second);
+						int type =	(lvname.find("refl") == std::string::npos) ? 1 : -1;
+						double dz = VolumeWrapper(itr.second).dz();
+						xtalMap_.emplace(itr.second,dz*type);
+					}
+				}
+			}
+			for (auto const& name : nameHCSD) {
+				for (const auto& itr : nameMap) {
+					const std::string &lvname = itr.first;
+					if (lvname.find(name) != std::string::npos) 
+						volHCSD_.emplace_back(itr.second);
+				}
+			}
+		}
+
+		//const accessors
+		const std::vector<const Volume*>& volEBSD() const { return volEBSD_; }
+		const std::vector<const Volume*>& volEESD() const { return volEESD_; }
+		const std::vector<const Volume*>& volHCSD() const { return volHCSD_; }
+		const std::map<const Volume*,double>& xtalMap() const { return xtalMap_; }
+
+	private:
+		//members
+		std::vector<const Volume*> volEBSD_, volEESD_, volHCSD_;
+		std::map<const Volume*,double> xtalMap_;
+};
+
+#endif

--- a/Calo/interface/CaloSteppingActionT.h
+++ b/Calo/interface/CaloSteppingActionT.h
@@ -55,7 +55,9 @@ public:
   typedef typename Traits::VolumeWrapper VolumeWrapper;
 
   CaloSteppingActionT(const edm::ParameterSet &p);
+  CaloSteppingActionT(const CaloSteppingActionT& other);
   ~CaloSteppingActionT() override;
+  CaloSteppingActionT& operator=(const CaloSteppingActionT& other);
 
   void produce(edm::Event&, const edm::EventSetup&) override;
 
@@ -67,10 +69,11 @@ public:
   void update(const EndEvent * evt)   override { update(EndEventWrapper(evt)); }
 
   // helpers
-  const edm::ParameterSet& GetParams() const;
   bool Merge(const CaloSteppingActionT<Traits>& other);
+  void clear();
 
 private:
+  void constructPointersAndProduces();
   void fillHits(edm::PCaloHitContainer& cc, int type);
   void fillPassiveHits(edm::PassiveHitContainer &cc);
   // subordinate functions with unified interfaces
@@ -109,7 +112,7 @@ private:
   double                                slopeLY_, birkC1EC_, birkSlopeEC_;
   double                                birkCutEC_, birkC1HC_, birkC2HC_;
   double                                birkC3HC_, timeSliceUnit_;
-  std::map<std::pair<int,CaloHitID>,CaloGVHit> hitMap_[nSD_];
+  std::array<std::map<std::pair<int,CaloHitID>,CaloGVHit>,nSD_> hitMap_;
   edm::PassiveHitContainer store_;
 };
 

--- a/Calo/interface/CaloSteppingActionT.h
+++ b/Calo/interface/CaloSteppingActionT.h
@@ -21,6 +21,7 @@
 #include "SimGVCore/Calo/interface/HcalNumberingScheme.h"
 #include "SimGVCore/Calo/interface/CaloGVHit.h"
 #include "SimGVCore/Calo/interface/HcalNumberingFromPS.h"
+#include "SimGVCore/Calo/interface/CaloMapT.h"
 
 #include "Geometry/EcalCommonData/interface/EcalBarrelNumberingScheme.h"
 #include "Geometry/EcalCommonData/interface/EcalBaseNumber.h"
@@ -89,6 +90,8 @@ private:
   double   getBirkHC(double dE, double step, double chg, double dens) const;
   void     saveHits(int flag);
 
+  const CaloMapT<Traits>& fillCaloMap() const;
+
   edm::ParameterSet params_;
 
   static const int                      nSD_= 3;
@@ -100,8 +103,7 @@ private:
 
   std::vector<std::string>              nameEBSD_, nameEESD_, nameHCSD_;
   std::vector<std::string>              nameHitC_;
-  std::vector<const Volume*>            volEBSD_, volEESD_, volHCSD_;
-  std::map<const Volume*,double>        xtalMap_;
+  const CaloMapT<Traits>*               caloMap_;
   std::map<const Volume*,std::string>   mapLV_;
   int                                   allSteps_, count_, eventID_;
   double                                slopeLY_, birkC1EC_, birkSlopeEC_;

--- a/Calo/interface/CaloSteppingActionT.icc
+++ b/Calo/interface/CaloSteppingActionT.icc
@@ -22,26 +22,24 @@
 
 template <class Traits>
 CaloSteppingActionT<Traits>::CaloSteppingActionT(const edm::ParameterSet &p) : 
-  params_(p),
+  params_(p.getParameter<edm::ParameterSet>("CaloSteppingAction")),
+  nameEBSD_(params_.getParameter<std::vector<std::string>>("EBSDNames")),
+  nameEESD_(params_.getParameter<std::vector<std::string>>("EESDNames")),
+  nameHCSD_(params_.getParameter<std::vector<std::string>>("HCSDNames")),
+  nameHitC_(params_.getParameter<std::vector<std::string>>("HitCollNames")),
   caloMap_(nullptr),
+  allSteps_(params_.getParameter<int>("AllSteps")),
   count_(0),
-  eventID_(0) {
-
-  edm::ParameterSet iC = p.getParameter<edm::ParameterSet>("CaloSteppingAction");
-  nameEBSD_       = iC.getParameter<std::vector<std::string> >("EBSDNames");
-  nameEESD_       = iC.getParameter<std::vector<std::string> >("EESDNames");
-  nameHCSD_       = iC.getParameter<std::vector<std::string> >("HCSDNames");
-  nameHitC_       = iC.getParameter<std::vector<std::string> >("HitCollNames");
-  allSteps_       = iC.getParameter<int>("AllSteps");
-  slopeLY_        = iC.getParameter<double>("SlopeLightYield");
-  birkC1EC_       = iC.getParameter<double>("BirkC1EC");
-  birkSlopeEC_    = iC.getParameter<double>("BirkSlopeEC");
-  birkCutEC_      = iC.getParameter<double>("BirkCutEC");
-  birkC1HC_       = iC.getParameter<double>("BirkC1HC");
-  birkC2HC_       = iC.getParameter<double>("BirkC2HC");
-  birkC3HC_       = iC.getParameter<double>("BirkC3HC");
-  timeSliceUnit_  = iC.getUntrackedParameter<double>("TimeSliceUnit",1.0);
-
+  eventID_(0),
+  slopeLY_(params_.getParameter<double>("SlopeLightYield")),
+  birkC1EC_(params_.getParameter<double>("BirkC1EC")),
+  birkSlopeEC_(params_.getParameter<double>("BirkSlopeEC")),
+  birkCutEC_(params_.getParameter<double>("BirkCutEC")),
+  birkC1HC_(params_.getParameter<double>("BirkC1HC")),
+  birkC2HC_(params_.getParameter<double>("BirkC2HC")),
+  birkC3HC_(params_.getParameter<double>("BirkC3HC")),
+  timeSliceUnit_(params_.getUntrackedParameter<double>("TimeSliceUnit",1.0))
+{
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("Step") << "CaloSteppingAction:: " << nameEBSD_.size() 
                            << " names for EB SD's";
@@ -67,16 +65,9 @@ CaloSteppingActionT<Traits>::CaloSteppingActionT(const edm::ParameterSet &p) :
   for (unsigned int k=0; k<nameHitC_.size(); ++k)
     edm::LogVerbatim("Step") << "[" << k << "] " << nameHitC_[k];
 #endif
-  ebNumberingScheme_ = std::make_unique<EcalBarrelNumberingScheme>();
-  eeNumberingScheme_ = std::make_unique<EcalEndcapNumberingScheme>();
-  hcNumberingPS_     = std::make_unique<HcalNumberingFromPS>(iC);
-  hcNumberingScheme_ = std::make_unique<HcalNumberingScheme>();
-  for (int k=0; k<CaloSteppingActionT::nSD_; ++k) {
-    slave_[k] = std::make_unique<CaloSlaveSD>(nameHitC_[k]);
-    produces<edm::PCaloHitContainer>(nameHitC_[k]);
-  }
-  if (allSteps_ > 0) 
-    produces<edm::PassiveHitContainer>("AllPassiveHits");
+
+  this->constructPointersAndProduces();
+
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("Step") << "CaloSteppingAction:: All Steps Flag " 
   			   << allSteps_ << " for passive hits";
@@ -84,9 +75,78 @@ CaloSteppingActionT<Traits>::CaloSteppingActionT(const edm::ParameterSet &p) :
 } 
 
 template <class Traits>
+CaloSteppingActionT<Traits>::CaloSteppingActionT(const CaloSteppingActionT<Traits>& other) :
+  params_(other.params_),
+  nameEBSD_(other.nameEBSD_),
+  nameEESD_(other.nameEESD_),
+  nameHCSD_(other.nameHCSD_),
+  nameHitC_(other.nameHitC_),
+  caloMap_(other.caloMap_),
+  mapLV_(other.mapLV_),
+  allSteps_(other.allSteps_),
+  count_(other.count_),
+  eventID_(other.eventID_),
+  slopeLY_(other.slopeLY_),
+  birkC1EC_(other.birkC1EC_),
+  birkSlopeEC_(other.birkSlopeEC_),
+  birkCutEC_(other.birkCutEC_),
+  birkC1HC_(other.birkC1HC_),
+  birkC2HC_(other.birkC2HC_),
+  birkC3HC_(other.birkC3HC_),
+  timeSliceUnit_(other.timeSliceUnit_),
+  hitMap_(other.hitMap_),
+  store_(other.store_)
+{
+  //handle unique_ptrs separately
+  this->constructPointersAndProduces();
+}
+
+template <class Traits>
 CaloSteppingActionT<Traits>::~CaloSteppingActionT() {
   edm::LogVerbatim("Step") << "CaloSteppingAction: -------->  Total number of "
                            << "selected entries : " << count_;
+}
+
+template <class Traits>
+CaloSteppingActionT<Traits>& CaloSteppingActionT<Traits>::operator=(const CaloSteppingActionT<Traits>& other) {
+  if(this != &other){
+    params_ = other.params_;
+    nameEBSD_ = other.nameEBSD_;
+    nameEESD_ = other.nameEESD_;
+    nameHCSD_ = other.nameHCSD_;
+    nameHitC_ = other.nameHitC_;
+    caloMap_ = other.caloMap_;
+    mapLV_ = other.mapLV_;
+    allSteps_ = other.allSteps_;
+    count_ = other.count_;
+    eventID_ = other.eventID_;
+    slopeLY_ = other.slopeLY_;
+    birkC1EC_ = other.birkC1EC_;
+    birkSlopeEC_ = other.birkSlopeEC_;
+    birkCutEC_ = other.birkCutEC_;
+    birkC1HC_ = other.birkC1HC_;
+    birkC2HC_ = other.birkC2HC_;
+    birkC3HC_ = other.birkC3HC_;
+    timeSliceUnit_ = other.timeSliceUnit_;
+    hitMap_ = other.hitMap_;
+    store_ = other.store_;
+  }
+
+  return *this;
+}
+
+template <class Traits>
+void CaloSteppingActionT<Traits>::constructPointersAndProduces() {
+  ebNumberingScheme_ = std::make_unique<EcalBarrelNumberingScheme>();
+  eeNumberingScheme_ = std::make_unique<EcalEndcapNumberingScheme>();
+  hcNumberingPS_     = std::make_unique<HcalNumberingFromPS>(params_);
+  hcNumberingScheme_ = std::make_unique<HcalNumberingScheme>();
+  for (int k=0; k<CaloSteppingActionT::nSD_; ++k) {
+    slave_[k] = std::make_unique<CaloSlaveSD>(nameHitC_[k]);
+    produces<edm::PCaloHitContainer>(nameHitC_[k]);
+  }
+  if (allSteps_ > 0) 
+    produces<edm::PassiveHitContainer>("AllPassiveHits");
 }
 
 template <class Traits>
@@ -106,12 +166,6 @@ void CaloSteppingActionT<Traits>::produce(edm::Event& e, const edm::EventSetup&)
 #endif
     e.put(std::move(hgcPH), "AllPassiveHits");
   }
-}
-
-//access stored params (to make another instance of this class)
-template <class Traits>
-const edm::ParameterSet& CaloSteppingActionT<Traits>::GetParams() const {
-  return params_;
 }
 
 template <class Traits>
@@ -199,9 +253,17 @@ void CaloSteppingActionT<Traits>::update(const BeginEventWrapper& evt) {
   edm::LogVerbatim("Step") <<"CaloSteppingAction: Begin of event = " 
                            << eventID_;
 #endif
+  clear();
+
+  for (int k=0; k<CaloSteppingActionT<Traits>::nSD_; ++k) {
+    slave_[k].get()->Initialize();
+  }
+}
+
+template <class Traits>
+void CaloSteppingActionT<Traits>::clear() {
   for (int k=0; k<CaloSteppingActionT<Traits>::nSD_; ++k) {
     hitMap_[k].clear();
-    slave_[k].get()->Initialize();
   }
   if (allSteps_ > 0)
     store_.clear();

--- a/Calo/interface/CaloSteppingActionT.icc
+++ b/Calo/interface/CaloSteppingActionT.icc
@@ -23,6 +23,7 @@
 template <class Traits>
 CaloSteppingActionT<Traits>::CaloSteppingActionT(const edm::ParameterSet &p) : 
   params_(p),
+  caloMap_(nullptr),
   count_(0),
   eventID_(0) {
 
@@ -160,51 +161,33 @@ void CaloSteppingActionT<Traits>::update(const BeginRunWrapper& run) {
   int irun = run.getRunID();
   edm::LogVerbatim("Step") << "CaloSteppingAction:: Begin of Run = " << irun;
 #endif
-  const auto& nameMap = VolumeWrapper::getVolumes();
-    for (auto const& name : nameEBSD_) {
-      for (const auto& itr : nameMap) {
-        const std::string &lvname = itr.first;
-        if (lvname.find(name) != std::string::npos) {
-          volEBSD_.emplace_back(itr.second);
-          int type =  (lvname.find("refl") == std::string::npos) ? -1 : 1;
-          double dz = VolumeWrapper(itr.second).dz();
-          xtalMap_.emplace(itr.second,dz*type);
-        }
-      }
-    }
-    for (auto const& name : nameEESD_) {
-      for (const auto& itr : nameMap) {
-        const std::string &lvname = itr.first;
-        if (lvname.find(name) != std::string::npos)  {
-          volEESD_.emplace_back(itr.second);
-          int type =  (lvname.find("refl") == std::string::npos) ? 1 : -1;
-          double dz = VolumeWrapper(itr.second).dz();
-          xtalMap_.emplace(itr.second,dz*type);
-        }
-      }
-    }
-    for (auto const& name : nameHCSD_) {
-      for (const auto& itr : nameMap) {
-        const std::string &lvname = itr.first;
-        if (lvname.find(name) != std::string::npos) 
-          volHCSD_.emplace_back(itr.second);
-      }
-    }
+
+  //eventually this should be replaced by an EventSetup object
+  caloMap_ = &(fillCaloMap());
+
     if (allSteps_ > 0) {
+      const auto& nameMap = VolumeWrapper::getVolumes();
       for (const auto& itr : nameMap) 
         mapLV_[itr.second] = itr.first;
     }
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("Step") << volEBSD_.size() << " logical volumes for EB SD";
-  for (unsigned int k=0; k<volEBSD_.size(); ++k)
-    edm::LogVerbatim("Step") << "[" << k << "] " << volEBSD_[k];
-  edm::LogVerbatim("Step") << volEESD_.size() << " logical volumes for EE SD";
-  for (unsigned int k=0; k<volEESD_.size(); ++k)
-    edm::LogVerbatim("Step") << "[" << k << "] " << volEESD_[k];
-  edm::LogVerbatim("Step") << volHCSD_.size() << " logical volumes for HC SD";
-  for (unsigned int k=0; k<volHCSD_.size(); ++k)
-    edm::LogVerbatim("Step") << "[" << k << "] " << volHCSD_[k];
+  edm::LogVerbatim("Step") << caloMap_->volEBSD().size() << " logical volumes for EB SD";
+  for (unsigned int k=0; k<caloMap_->volEBSD().size(); ++k)
+    edm::LogVerbatim("Step") << "[" << k << "] " << caloMap_->volEBSD()[k];
+  edm::LogVerbatim("Step") << caloMap_->volEESD().size() << " logical volumes for EE SD";
+  for (unsigned int k=0; k<caloMap_->volEESD().size(); ++k)
+    edm::LogVerbatim("Step") << "[" << k << "] " << caloMap_->volEESD()[k];
+  edm::LogVerbatim("Step") << caloMap_->volHCSD().size() << " logical volumes for HC SD";
+  for (unsigned int k=0; k<caloMap_->volHCSD().size(); ++k)
+    edm::LogVerbatim("Step") << "[" << k << "] " << caloMap_->volHCSD()[k];
 #endif
+}
+
+template <class Traits>
+const CaloMapT<Traits>& CaloSteppingActionT<Traits>::fillCaloMap() const {
+  static const CaloMapT<Traits> caloMap(nameEBSD_,nameEESD_,nameHCSD_);
+
+  return caloMap;
 }
 
 //=================================================================== per EVENT
@@ -230,9 +213,9 @@ void CaloSteppingActionT<Traits>::update(const StepWrapper& aStep) {
 
   NaNTrap(aStep);
   auto lv = aStep.getVolume();
-  bool hc = (std::find(volHCSD_.begin(),volHCSD_.end(),lv)!=volHCSD_.end());
-  bool eb = (std::find(volEBSD_.begin(),volEBSD_.end(),lv)!=volEBSD_.end());
-  bool ee = (std::find(volEESD_.begin(),volEESD_.end(),lv)!=volEESD_.end());
+  bool hc = (std::find(caloMap_->volHCSD().begin(),caloMap_->volHCSD().end(),lv)!=caloMap_->volHCSD().end());
+  bool eb = (std::find(caloMap_->volEBSD().begin(),caloMap_->volEBSD().end(),lv)!=caloMap_->volEBSD().end());
+  bool ee = (std::find(caloMap_->volEESD().begin(),caloMap_->volEESD().end(),lv)!=caloMap_->volEESD().end());
   if  (hc || eb || ee) {
     double dEStep = aStep.getEnergyDeposit();
     double time   = aStep.getTime();
@@ -283,13 +266,13 @@ void CaloSteppingActionT<Traits>::update(const StepWrapper& aStep) {
                      (eeNumberingScheme_->getUnitID(theBaseNumber)));
       if (unitID > 0 && dEStep > 0.0) {
         double dz = aStep.getDz();
-        auto ite   = xtalMap_.find(lv);
-        double crystalLength = ((ite == xtalMap_.end()) ? 230.0 : 
+        auto ite   = caloMap_->xtalMap().find(lv);
+        double crystalLength = ((ite == caloMap_->xtalMap().end()) ? 230.0 : 
                                 std::abs(ite->second));
-        double crystalDepth = ((ite == xtalMap_.end()) ? 0.0 :
+        double crystalDepth = ((ite == caloMap_->xtalMap().end()) ? 0.0 :
                                (std::abs(0.5*(ite->second)+dz)));
         double radl   = aStep.getRadlen();
-        bool   flag   = ((ite == xtalMap_.end()) ? true : (((ite->second) >= 0)
+        bool   flag   = ((ite == caloMap_->xtalMap().end()) ? true : (((ite->second) >= 0)
                                                            ? true : false));
         auto   depth  = getDepth(flag, crystalDepth, radl);
         dEStep        *= (getBirkL3(dEStep,aStep.getStepLength(), aStep.getCharge(), aStep.getDensity()) * 


### PR DESCRIPTION
Changes:
1. Store calorimeter volume maps from Geant in a single magic static object. This reduces the initialization time and memory overhead for both simulations (especially GeantV). Eventually, this should be replaced by something like EventSetup or a read-only member from the top-level producer (`OscarMTProducer` or `GeantVProducer`).
2. Ensure that merged event output cannot be modified after merging by copying it to a separate cache known only to the derived `CMSEvent` class (formerly `EventCB`) and the `GeantVProducer`. This requires clearly-defined copy constructors and assignment operators, but removes the need to keep track of GeantV's event slot number in the CMSSW producer, and is safer overall.
3. Clear `CMSData` output members immediately after merging. Previously, waiting until the next `BeginEvent()` call to clear the `hitMap_` was causing a data race.
4. Add single track mode switch and some fixes in test scripts.

This PR was developed alongside to some GeantV data race fixes that can be found in: https://gitlab.cern.ch/GeantV/geant/merge_requests/341.